### PR TITLE
rescued from exception in sample script

### DIFF
--- a/scan.rb
+++ b/scan.rb
@@ -8,5 +8,9 @@ urls.uniq!
 
 Legalese::Reporter.print_key
 urls.each do |url|
-  Legalese::Reporter.new(url).run
+  begin
+    Legalese::Reporter.new(url).run
+  rescue OpenSSL::SSL::SSLError
+    puts "Failed with #{url} due to OpenSSL errors"
+  end
 end


### PR DESCRIPTION
Running bundle exec ruby scan.rb turned up errors for websites with certificate issues and stops the search in terminal. Adding the rescue exception allows the user to continue through the urls.txt file without stopping the search, yet still displaying the error (which shows as "Failed with #{url} due to OpenSSL errors").  
- Daniel, Yohan, Chris, and Adrian. 
